### PR TITLE
Holiday API Client - improved response mapping

### DIFF
--- a/src/main/java/com/github/agogs/holidayapi/model/Holiday.java
+++ b/src/main/java/com/github/agogs/holidayapi/model/Holiday.java
@@ -1,18 +1,20 @@
 package com.github.agogs.holidayapi.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
 import lombok.Setter;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
         "name",
         "date",
         "observed",
         "public"
 })
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(value = {"country", "uuid", "weekday"})
 public class Holiday {
 
     @JsonProperty("name")

--- a/src/main/java/com/github/agogs/holidayapi/model/HolidayAPIResponse.java
+++ b/src/main/java/com/github/agogs/holidayapi/model/HolidayAPIResponse.java
@@ -1,5 +1,6 @@
 package com.github.agogs.holidayapi.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -12,12 +13,15 @@ import java.util.List;
 /**
  * This class represents the complete JSON response of the API <code>/v1/holidays</code>
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
         "status",
         "error",
+        "warning",
+        "requests",
         "holidays"
 })
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class HolidayAPIResponse {
 
     @JsonProperty("status")
@@ -35,12 +39,24 @@ public class HolidayAPIResponse {
     @Setter
     private String error;
 
+    @JsonProperty("warning")
+    @Getter
+    @Setter
+    private String warning;
+
+    @JsonProperty("requests")
+    @Getter
+    @Setter
+    private RemainingRequests remainingRequests;
+
     @Override
     public String toString() {
         return "HolidayResponse{" +
                 "status=" + status +
                 ", holidays=" + holidays +
-                ", error='" + error + '\'' +
+                ", error='" + (error == null ? "" : error) + '\'' +
+                ", warning='" + (warning == null ? "" : warning) + '\'' +
+                ", requests='" + remainingRequests +
                 '}';
     }
 }

--- a/src/main/java/com/github/agogs/holidayapi/model/RemainingRequests.java
+++ b/src/main/java/com/github/agogs/holidayapi/model/RemainingRequests.java
@@ -1,0 +1,46 @@
+package com.github.agogs.holidayapi.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Model class representing the remaining requests for all Holiday API subscription plans (10k requests per month for the free plan and 1M for the paid plans).
+ *
+ */
+@JsonPropertyOrder({
+        "used",
+        "remaining",
+        "resets"
+})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RemainingRequests {
+
+    @JsonProperty("used")
+    @Getter
+    @Setter
+    private int used;
+
+    @JsonProperty("remaining")
+    @Getter
+    @Setter
+    private int remaining;
+
+    @JsonProperty("resets")
+    @Getter
+    @Setter
+    private String resetDateTime;
+
+    @Override
+    public String toString() {
+        return "RemainingRequests{" +
+                "used=" + used +
+                ", remaining=" + remaining +
+                ", resetDateTime='" + (resetDateTime == null ? "" : resetDateTime) + '\'' +
+                '}';
+    }
+}

--- a/src/test/java/com/github/agogs/holidayapi/api/impl/HolidayAPIConsumerTest.java
+++ b/src/test/java/com/github/agogs/holidayapi/api/impl/HolidayAPIConsumerTest.java
@@ -13,19 +13,31 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 
-import static com.github.agogs.holidayapi.api.testutil.MockResponse.*;
+import static com.github.agogs.holidayapi.api.testutil.MockResponse.RESPONSE_200;
+import static com.github.agogs.holidayapi.api.testutil.MockResponse.RESPONSE_400;
+import static com.github.agogs.holidayapi.api.testutil.MockResponse.RESPONSE_401;
+import static com.github.agogs.holidayapi.api.testutil.MockResponse.RESPONSE_403;
+import static com.github.agogs.holidayapi.api.testutil.MockResponse.RESPONSE_429;
+import static com.github.agogs.holidayapi.api.testutil.MockResponse.RESPONSE_500;
+import static com.github.agogs.holidayapi.api.testutil.MockResponse.response200;
+import static com.github.agogs.holidayapi.api.testutil.MockResponse.response400;
+import static com.github.agogs.holidayapi.api.testutil.MockResponse.response401;
+import static com.github.agogs.holidayapi.api.testutil.MockResponse.response402;
+import static com.github.agogs.holidayapi.api.testutil.MockResponse.response403;
+import static com.github.agogs.holidayapi.api.testutil.MockResponse.response429;
+import static com.github.agogs.holidayapi.api.testutil.MockResponse.response500;
 
 /**
  * Test the behaviour of the methods implemented in {@link HolidayAPIConsumer}.
  * <p>Each test method tests for a response code of the API. The responses for the following response codes are tested.</p>
  * <ul>
- *     <li>200</li>
- *     <li>400</li>
- *     <li>401</li>
- *     <li>402</li>
- *     <li>403</li>
- *     <li>429</li>
- *     <li>500</li>
+ * <li>200</li>
+ * <li>400</li>
+ * <li>401</li>
+ * <li>402</li>
+ * <li>403</li>
+ * <li>429</li>
+ * <li>500</li>
  * </ul>
  */
 public class HolidayAPIConsumerTest {
@@ -49,7 +61,6 @@ public class HolidayAPIConsumerTest {
         Assert.assertTrue(response != null, "Response is null");
         Assert.assertTrue(response.getStatus() == 200, "Response code is NOT 200");
         Assert.assertTrue(response.getError() == null, "error message is NOT null");
-
     }
 
     @Test

--- a/src/test/java/com/github/agogs/holidayapi/api/impl/ObjectMapperTest.java
+++ b/src/test/java/com/github/agogs/holidayapi/api/impl/ObjectMapperTest.java
@@ -1,0 +1,114 @@
+package com.github.agogs.holidayapi.api.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import com.github.agogs.holidayapi.model.HolidayAPIResponse;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests the behavior of the object mapper for Holiday API responses.
+ *
+ * @author adrianpop
+ */
+public class ObjectMapperTest {
+
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    public void mapValidResponse() throws Exception {
+        String response = "{\"status\":200,\"holidays\":[{\"name\":\"May Day\",\"date\":\"2017-05-01\",\"observed\":\"2017-05-01\",\"public\":false}], \"warning\":\"Warning message\", " +
+                "\"requests\":{\"used\":5,\"remaining\":9995, \"resets\":\"2020-05-01 00:00:0\"}}";
+
+        HolidayAPIResponse mappedResponse = objectMapper.readValue(response, HolidayAPIResponse.class);
+
+        assertNotNull(mappedResponse);
+        assertEquals(Integer.valueOf(200), mappedResponse.getStatus());
+        assertEquals(1, mappedResponse.getHolidays().size());
+        assertEquals("May Day", mappedResponse.getHolidays().get(0).getName());
+        assertEquals("2017-05-01", mappedResponse.getHolidays().get(0).getDate());
+        assertEquals("2017-05-01", mappedResponse.getHolidays().get(0).getObserved());
+        assertFalse(mappedResponse.getHolidays().get(0).getIsPublic());
+        assertEquals("Warning message", mappedResponse.getWarning());
+        assertEquals(5, mappedResponse.getRemainingRequests().getUsed());
+        assertEquals(9995, mappedResponse.getRemainingRequests().getRemaining());
+        assertEquals("2020-05-01 00:00:0", mappedResponse.getRemainingRequests().getResetDateTime());
+    }
+
+    @Test
+    public void mapResponseCountryUuidWeekdayInHolidayIgnored() throws Exception {
+        String response = "{\"status\":200,\"holidays\":[{\"name\":\"May Day\",\"date\":\"2017-05-01\",\"observed\":\"2017-05-01\",\"public\":false, " +
+                "\"country\":\"RO\", \"uuid\":\"e84e6430-a789-4a49-9bbd-76edbf8cf34\", \"weekday\":{}}], \"warning\":\"Warning message\", \"requests\":{\"used\":5,\"remaining\":9995, " +
+                "\"resets\":\"2020-05-01 00:00:0\"}}";
+
+        HolidayAPIResponse mappedResponse = objectMapper.readValue(response, HolidayAPIResponse.class);
+
+        assertNotNull(mappedResponse);
+        assertEquals(1, mappedResponse.getHolidays().size());
+    }
+
+    @Test
+    public void mapEmptyResponse() throws Exception {
+        String response = "{}";
+
+        HolidayAPIResponse mappedResponse = objectMapper.readValue(response, HolidayAPIResponse.class);
+
+        assertNotNull(mappedResponse);
+        assertNull(mappedResponse.getStatus());
+        assertNull(mappedResponse.getWarning());
+        assertNull(mappedResponse.getRemainingRequests());
+        assertNull(mappedResponse.getStatus());
+        assertNull(mappedResponse.getError());
+    }
+
+    @Test
+    public void mapResponseNoHolidays() throws Exception {
+        String response = "{\"status\":200, \"warning\":\"Warning message\", \"holidays\":[], \"requests\":{\"used\":5,\"remaining\":9995, " +
+                "\"resets\":\"2020-05-01 00:00:0\"}}";
+
+        HolidayAPIResponse mappedResponse = objectMapper.readValue(response, HolidayAPIResponse.class);
+
+        assertNotNull(mappedResponse);
+    }
+
+    @Test
+    public void mapResponseUnexpectedFieldIgnored() throws Exception {
+        String response = "{\"status\":200,\"holidays\":[{\"name\":\"May Day\",\"date\":\"2017-05-01\",\"observed\":\"2017-05-01\",\"public\":false, " +
+                "\"country\":\"RO\", \"uuid\":\"e84e6430-a789-4a49-9bbd-76edbf8cf34\"}], \"warning\":\"Warning message\", \"requests\":{\"used\":5,\"remaining\":9995, " +
+                "\"resets\":\"2020-05-01 00:00:0\"}, \"unexpectedField\":\"value\"}";
+
+        HolidayAPIResponse mappedResponse = objectMapper.readValue(response, HolidayAPIResponse.class);
+
+        assertNotNull(mappedResponse);
+    }
+
+    @Test
+    public void mapResponseUnexpectedFieldRemainingRequestsIgnored() throws Exception {
+        String response = "{\"status\":200,\"holidays\":[{\"name\":\"May Day\",\"date\":\"2017-05-01\",\"observed\":\"2017-05-01\",\"public\":false, " +
+                "\"country\":\"RO\", \"uuid\":\"e84e6430-a789-4a49-9bbd-76edbf8cf34\"}], \"warning\":\"Warning message\", \"requests\":{\"used\":5,\"remaining\":9995, " +
+                "\"resets\":\"2020-05-01 00:00:0\", \"unexpectedField\":\"value\"}}";
+
+        HolidayAPIResponse mappedResponse = objectMapper.readValue(response, HolidayAPIResponse.class);
+
+        assertNotNull(mappedResponse);
+    }
+
+    @Test(expected = UnrecognizedPropertyException.class)
+    public void mapResponseUnexpectedFieldHolidayThrowsException() throws Exception {
+        String response = "{\"status\":200,\"holidays\":[{\"name\":\"May Day\",\"date\":\"2017-05-01\",\"observed\":\"2017-05-01\",\"public\":false, " +
+                "\"country\":\"RO\", \"uuid\":\"e84e6430-a789-4a49-9bbd-76edbf8cf34\", \"unexpectedField\":\"value\"}], \"warning\":\"Warning message\", \"requests\":{\"used\":5,\"remaining\":9995, " +
+                "\"resets\":\"2020-05-01 00:00:0\"}}";
+
+        HolidayAPIResponse mappedResponse = objectMapper.readValue(response, HolidayAPIResponse.class);
+    }
+}

--- a/src/test/java/com/github/agogs/holidayapi/api/testutil/MockResponse.java
+++ b/src/test/java/com/github/agogs/holidayapi/api/testutil/MockResponse.java
@@ -14,7 +14,9 @@ public abstract class MockResponse {
     private static ObjectMapper mapper = new ObjectMapper();
 
     //Only the status code is important, the error message is irrelevant for testing
-    public static String RESPONSE_200 = "{\"status\":200,\"holidays\":[{\"name\":\"May Day\",\"date\":\"2017-05-01\",\"observed\":\"2017-05-01\",\"public\":false}]}";
+    public static String RESPONSE_200 = "{\"status\":200,\"holidays\":[{\"name\":\"May Day\",\"date\":\"2017-05-01\",\"observed\":\"2017-05-01\",\"public\":false, " +
+            "\"country\":\"RO\", \"uuid\":\"e84e6430-a789-4a49-9bbd-76edbf8cf34\"}], \"warning\":\"Warning message\", \"requests\":{\"used\":5,\"remaining\":9995, " +
+            "\"resets\":\"2020-05-01 00:00:0\"}}";
     public static String RESPONSE_400 = "{\"status\":400,\"error\":\"Something went wrong on your end\"}";
     public static String RESPONSE_401 = "{\"status\":401,\"error\":\"Unauthorized\"}";
     public static String RESPONSE_402 = "{\"status\":402,\"error\":\"Payment required\"}";


### PR DESCRIPTION
This branch contains changes to the Jackson JSON mapping so all Holiday API responses are properly mapped into response objects. 

In the previous version this was not possible because response fields like "requests" or "warning" were not expected neither marked as ignored thus the object mapping failed and the client was unusable. 

As of april 2019, the Holiday API sends the "warning" field in the response for free subscriptions. The "requests" field is used to help API consumers track the remaining API requests in their subscription plan.